### PR TITLE
support gnome 43

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/velitasali/gnome-awesome-tiles-extension",
   "uuid": "awesome-tiles@velitasali.com",


### PR DESCRIPTION
With this change, I was able to install and use awesome-tiles on gnome 43 (ubuntu 22.10) 

Fixes #27