### PR TITLE
Add support for multi dimensional tiling

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -234,7 +234,7 @@ class Extension {
     let iteration = successive ? prev.iteration : 0
     let rect = this._computeWindowRect(window, top, bottom, left, right, steps[iteration], center)
 
-    // Ensure the new window size differs from the previous one.
+    // Iterate through the tiling steps until we find one that changes the window size.
     for (const end = iteration; successive && _isRectEqual(rect, prev.rect);) {
       iteration = (iteration + 1) % steps.length
       if (iteration === end)

--- a/src/extension.js
+++ b/src/extension.js
@@ -249,8 +249,8 @@ class Extension {
   }
 
   _computeWindowRect(window, top, bottom, left, right, step, center) {
-    const stepWidth = 1.0 - step[0]
-    const stepHeight = step.length > 1 ? (1.0 - step[1]) : stepWidth
+    const widthFactor = 1.0 - step[0]
+    const heightFactor = step.length > 1 ? (1.0 - step[1]) : widthFactor
 
     const workArea = this._calculateWorkspaceArea(window)
     let { x, y, width, height } = workArea
@@ -261,17 +261,17 @@ class Extension {
       const monitor = window.get_monitor()
       const monitorGeometry = global.display.get_monitor_geometry(monitor)
       const isVertical = monitorGeometry.width < monitorGeometry.height
-      const widthStep = isVertical ? stepWidth / 2 : stepWidth
-      const heightStep = isVertical ? stepHeight : stepHeight / 2
+      const centerTilingWidthFactor = isVertical ? widthFactor / 2 : widthFactor
+      const centerTilingHeightFactor = isVertical ? heightFactor : heightFactor / 2
 
-      width -= width * widthStep
-      height -= height * heightStep
+      width -= width * centerTilingWidthFactor
+      height -= height * centerTilingHeightFactor
       x += (workArea.width - width) / 2
       y += (workArea.height - height) / 2
 
     } else {
-      if (left !== right) width -= width * stepWidth
-      if (top !== bottom) height -= height * stepHeight
+      if (left !== right) width -= width * widthFactor
+      if (top !== bottom) height -= height * heightFactor
       if (!left) x += (workArea.width - width) / (right ? 1 : 2)
       if (!top) y += (workArea.height - height) / (bottom ? 1 : 2)
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,11 +48,14 @@ function parseTilingSteps(value, defaultValue) {
     return value
       .split(",")
       .map((step) => {
-        const result = Math.max(0.0, Math.min(1.0, parseFloat(step.trim())))
-        if (isNaN(result) || typeof result !== 'number') {
-          throw new Error("Expected a number")
-        }
-        return result
+        const numbers = step.split(";").map((str) => {
+          const number = Math.max(0.0, Math.min(1.0, parseFloat(str.trim())))
+          if (isNaN(number) || typeof number !== 'number') {
+            throw new Error("Expected a number")
+          }
+          return number
+        })
+        return numbers
       })
   } catch {
     return defaultValue


### PR DESCRIPTION
### Motivation

At the moment the extension does not support tiling steps with different factors for width and height. This PR adds support for multi dimensional tiling steps. By extending the tiling step syntax, users can now specify different factors for width and height. E.g., a value of `0.3;0.7` specifies a window with 30% of the screen width and 70% of the screen height. The new syntax is backward compatible. `0.7, 1, 0.5` is still a valid input. The new syntax can also be mixed with the old one `0.3;0.7, 0.3, 0.7, 0.5`.

#### Handling edge cases

This new feature can result in some edge cases that have to be addressed. For instance, the tiling steps `0.3;0.7, 0.3, 0.5` will result in the same window size for the first two steps, when tiling a window to a side (left, right, top or bottom). To address such edge cases a mechanism to skip steps that have no effect on the window was added:

1) If the new window size is equal to the current window size compute the window size for the next tiling step.
2) Repeat 1) until a change is detected or all tiling steps have been tried.