### PR TITLE
Add Percentage-Based Bottom Gap Option for Enhanced Dock Compatibility

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -125,7 +125,11 @@ export default class AwesomeTilesExtension extends Extension {
     // Calculate additional bottom gap if enabled
     let bottomGap = 0
     if (this._isBottomGapEnabled) {
-      bottomGap = Math.round(this._bottomGapSize / 100 * workspaceArea.height)
+      // Check if bottom gap should only be applied to the main screen
+      const isPrimaryMonitor = monitor === global.display.get_primary_monitor();
+      if (!this._isBottomGapMainScreenOnly || isPrimaryMonitor) {
+        bottomGap = Math.round(this._bottomGapSize / 100 * workspaceArea.height)
+      }
     }
     
     return {
@@ -178,6 +182,10 @@ export default class AwesomeTilesExtension extends Extension {
 
   get _isBottomGapEnabled() {
     return this._settings.get_boolean("enable-bottom-gap")
+  }
+
+  get _isBottomGapMainScreenOnly() {
+    return this._settings.get_boolean("bottom-gap-main-screen-only")
   }
 
   get _bottomGapSize() {

--- a/src/extension.js
+++ b/src/extension.js
@@ -100,7 +100,7 @@ export default class AwesomeTilesExtension extends Extension {
     const gap = this._gapSize
 
     
-    if (gap <= 0) return {
+    if (gap <= 0 && !this._isBottomGapEnabled) return {
       x: workspaceArea.x,
       y: workspaceArea.y,
       height: workspaceArea.height,
@@ -122,12 +122,19 @@ export default class AwesomeTilesExtension extends Extension {
       gaps.y = temp
     }
     
+    // Calculate additional bottom gap if enabled
+    let bottomGap = 0
+    if (this._isBottomGapEnabled) {
+      bottomGap = Math.round(this._bottomGapSize / 100 * workspaceArea.height)
+    }
+    
     return {
       x: workspaceArea.x + gaps.x,
       y: workspaceArea.y + gaps.y,
-      height: workspaceArea.height - (gaps.y * 2),
+      height: workspaceArea.height - (gaps.y * 2) - bottomGap,
       width: workspaceArea.width - (gaps.x * 2),
       gaps,
+      bottomGap,
     }
   }
 
@@ -167,6 +174,14 @@ export default class AwesomeTilesExtension extends Extension {
 
   get _isInnerGapsEnabled() {
     return this._settings.get_boolean("enable-inner-gaps")
+  }
+
+  get _isBottomGapEnabled() {
+    return this._settings.get_boolean("enable-bottom-gap")
+  }
+
+  get _bottomGapSize() {
+    return this._settings.get_int("bottom-gap-size")
   }
 
   get _tilingStepsCenter() {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -164,6 +164,36 @@ export default class AwesomeTilesPreferences extends ExtensionPreferences {
       Gio.SettingsBindFlags.DEFAULT,
     )
 
+    // Bottom gap settings
+    const bottomGapSwitchRow = new Adw.SwitchRow({
+      title: _('Enable Additional Bottom Gap'),
+      subtitle: _('Add an additional gap at the bottom of the screen to prevent dock overlap.'),
+    })
+    gapsGroup.add(bottomGapSwitchRow)
+    settings.bind(
+      'enable-bottom-gap',
+      bottomGapSwitchRow,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    )
+
+    const bottomGapSizeSpinRow = new Adw.SpinRow({
+      title: _('Bottom Gap Size'),
+      subtitle: _('Additional gap size at the bottom of the screen in percentage.'),
+      adjustment: new Gtk.Adjustment({
+        lower: 0,
+        upper: 50,
+        'step-increment': 5,
+      })
+    })
+    gapsGroup.add(bottomGapSizeSpinRow)
+    settings.bind(
+      'bottom-gap-size',
+      bottomGapSizeSpinRow,
+      'value',
+      Gio.SettingsBindFlags.DEFAULT,
+    )
+
     return gapsGroup
   }
 

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -194,6 +194,18 @@ export default class AwesomeTilesPreferences extends ExtensionPreferences {
       Gio.SettingsBindFlags.DEFAULT,
     )
 
+    const bottomGapMainScreenOnlySwitchRow = new Adw.SwitchRow({
+      title: _('Bottom Gap Main Screen Only'),
+      subtitle: _('Apply the additional bottom gap only on the main screen.'),
+    })
+    gapsGroup.add(bottomGapMainScreenOnlySwitchRow)
+    settings.bind(
+      'bottom-gap-main-screen-only',
+      bottomGapMainScreenOnlySwitchRow,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    )
+
     return gapsGroup
   }
 

--- a/src/schemas/org.gnome.shell.extensions.awesome-tiles.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.awesome-tiles.gschema.xml
@@ -137,6 +137,16 @@
       <summary>Gap Size Increments</summary>
       <description>Determine how much gap size adjust by keybinding.</description>
     </key>
+    <key name="enable-bottom-gap" type="b">
+      <default>false</default>
+      <summary>Enable Additional Bottom Gap</summary>
+      <description>Add an additional gap at the bottom of the screen to prevent dock overlap.</description>
+    </key>
+    <key name="bottom-gap-size" type="i">
+      <default>10</default>
+      <summary>Bottom Gap Size</summary>
+      <description>Additional gap size at the bottom of the screen in percentage.</description>
+    </key>
     <key name="tiling-steps-center" type="s">
       <default><![CDATA['1, 0.75, 0.5']]></default>
       <summary>Center Tiling Steps</summary>

--- a/src/schemas/org.gnome.shell.extensions.awesome-tiles.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.awesome-tiles.gschema.xml
@@ -147,6 +147,11 @@
       <summary>Bottom Gap Size</summary>
       <description>Additional gap size at the bottom of the screen in percentage.</description>
     </key>
+    <key name="bottom-gap-main-screen-only" type="b">
+      <default>false</default>
+      <summary>Bottom Gap Main Screen Only</summary>
+      <description>Apply the additional bottom gap only on the main screen.</description>
+    </key>
     <key name="tiling-steps-center" type="s">
       <default><![CDATA['1, 0.75, 0.5']]></default>
       <summary>Center Tiling Steps</summary>


### PR DESCRIPTION
This PR introduces a new feature that lets users define a bottom gap as a percentage of the screen size. This enhancement ensures that tiles in Awesome Tiles are properly spaced to prevent overlapping with the dock, regardless of varying screen resolutions and dock sizes. The implementation includes updates to the settings interface, offering users a more flexible and dynamic layout adjustment.

+ Added a option to make the custom bottom gap on main screen only.

![image](https://github.com/user-attachments/assets/c5a3dea3-0329-4602-aa28-1de203b236c3)
