### PR TITLE
Update metadata.json to add support to Gnome 48

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,7 +7,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/velitasali/gnome-awesome-tiles-extension",
   "uuid": "awesome-tiles@velitasali.com",


### PR DESCRIPTION
The extension seems to work properly on GNOME 48.