### PR TITLE
Partial fix for issue #59: Support for Gnome 49

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -8,9 +8,10 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/velitasali/gnome-awesome-tiles-extension",
   "uuid": "awesome-tiles@velitasali.com",
-  "version": 14
+  "version": 15
 }

--- a/src/windowMover.js
+++ b/src/windowMover.js
@@ -1,6 +1,7 @@
 import Clutter from 'gi://Clutter'
 import Gio from 'gi://Gio'
 import Meta from 'gi://Meta'
+import Mtk from 'gi://Mtk';
 
 export class WindowMover {
   constructor() {
@@ -35,7 +36,7 @@ export class WindowMover {
     rect ??= window.get_frame_rect()
     const lastValue = this._desktopSettings.get_boolean("enable-animations")
     if (lastValue) this._desktopSettings.set_boolean("enable-animations",false)
-    window.unmaximize(Meta.MaximizeFlags.BOTH)
+    window.unmaximize()
     window.move_resize_frame(false, rect.x, rect.y, rect.width, rect.height)
     if (lastValue) this._desktopSettings.set_boolean("enable-animations",true)
   }
@@ -74,7 +75,7 @@ export class WindowMover {
     const innerRectBefore = window.get_frame_rect()
     const outterRectBefore = window.get_buffer_rect()
     const actor = window.get_compositor_private()
-    const isMaximized = window.get_maximized()
+    const isMaximized = window.is_maximized()
     const lastAnimation = this._windowAnimations.find(item=>item.window === window)
     const thisAnimation = {}
     let clone


### PR DESCRIPTION
This PR partially fixes issue #59 by preventing the extension from crashing on Gnome 49. The extension now loads correctly, but the corner-tiling shortcut (Super + 9) does not work; the default Gnome behavior (switching to the previous workspace) still occurs.